### PR TITLE
don't send error notifications for FacesFileNotFoundExceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.sun.faces</groupId>
+      <artifactId>jsf-impl</artifactId>
+      <version>2.1.28-jbossorg-5</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.spec.javax.el</groupId>
       <artifactId>jboss-el-api_2.2_spec</artifactId>
       <version>1.0.4.Final</version>

--- a/src/main/java/org/ccci/debug/ExceptionContext.java
+++ b/src/main/java/org/ccci/debug/ExceptionContext.java
@@ -12,6 +12,7 @@ import javax.faces.validator.ValidatorException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import com.sun.faces.context.FacesFileNotFoundException;
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
@@ -191,7 +192,8 @@ public class ExceptionContext
         ImmutableSet.<Class<? extends Throwable>>of(
             ViewExpiredException.class, 
             AuthorizationException.class,
-            BackButtonException.class);
+            BackButtonException.class,
+            FacesFileNotFoundException.class);
 
     /**
      * Some exceptions don't warrant an exception notification, and result from rare, recoverable circumstances


### PR DESCRIPTION
These are 404-type errors - no need for a notification.