### PR TITLE
fix email address validation for addresses with trailing spaces

### DIFF
--- a/src/main/java/org/ccci/util/mail/EmailAddress.java
+++ b/src/main/java/org/ccci/util/mail/EmailAddress.java
@@ -51,7 +51,9 @@ public class EmailAddress extends ValueObject implements Serializable, InternetA
         Preconditions.checkNotNull(emailAddress, "emailAddress is null");
         try
         {
-            new InternetAddress(emailAddress, false).validate();
+            InternetAddress internetAddress = new InternetAddress();
+            internetAddress.setAddress(emailAddress);
+            internetAddress.validate();
         }
         catch (AddressException e)
         {

--- a/src/test/java/org/ccci/util/mail/EmailAddressTest.java
+++ b/src/test/java/org/ccci/util/mail/EmailAddressTest.java
@@ -10,4 +10,10 @@ public class EmailAddressTest
     {
         EmailAddress.valueOf("matt.drees!@ccci.org");
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testValidation_noTrailingSpaces()
+    {
+        EmailAddress.valueOf("matt.drees@ccci.org ");
+    }
 }


### PR DESCRIPTION
This PR fixes a problem that caused etimesheet email notifications to fail recently. (See https://secure.helpscout.net/conversation/90084633/6390/).

Note: eTimesheet actually uses a version of util that wasn't migrated to git (jboss-4-compatible-1-SNAPSHOT). The changes in this PR were duplicated to the svn branch for that version: arkham.ccci.org/svn/java/branches/commons/util/jboss-4-compatible/.